### PR TITLE
Nullifier computation

### DIFF
--- a/src/extractor.test.ts
+++ b/src/extractor.test.ts
@@ -13,7 +13,7 @@ import {
   stateExtractor,
   timestampExtractor,
   photoExtractor,
-  photoExtractorChunked
+  photoExtractorChunked,
 } from './extractors.js';
 import {
   createDelimitedData,
@@ -104,13 +104,17 @@ describe('Extractor circuit tests', () => {
       expect(photoBytes.toString()).toEqual(slicedPhotoBytes.toString());
     });
     it('should extract photo', async () => {
-
-      const photoChunks = photoExtractorChunked(nDelimitedData, delimiterIndices);
+      const photoChunks = photoExtractorChunked(
+        nDelimitedData,
+        delimiterIndices
+      );
 
       // const nullifierSeed = Field.random();
       const nullifierHash = nullifier(Field.from(0), photoChunks);
 
-      expect(nullifierHash.toBigInt()).toEqual(10925948596859628672570915913938655172287655450674278034619273873192962315293n);
+      expect(nullifierHash.toBigInt()).toEqual(
+        10925948596859628672570915913938655172287655450674278034619273873192962315293n
+      );
     });
   });
 });

--- a/src/extractor.test.ts
+++ b/src/extractor.test.ts
@@ -9,10 +9,11 @@ import { getQRData, TEST_DATA } from './getQRData.js';
 import {
   ageAndGenderExtractor,
   delimitData,
-  photoExtractor,
   pincodeExtractor,
   stateExtractor,
   timestampExtractor,
+  photoExtractor,
+  photoExtractorChunked
 } from './extractors.js';
 import {
   createDelimitedData,
@@ -20,6 +21,7 @@ import {
   charBytesToInt,
   createPaddedQRData,
 } from './testUtils.js';
+import { nullifier } from './nullifier.js';
 
 describe('Extractor circuit tests', () => {
   let nDelimitedData: Field[];
@@ -100,6 +102,15 @@ describe('Extractor circuit tests', () => {
       );
       // Our state here is at length 5, so try:
       expect(photoBytes.toString()).toEqual(slicedPhotoBytes.toString());
+    });
+    it('should extract photo', async () => {
+
+      const photoChunks = photoExtractorChunked(nDelimitedData, delimiterIndices);
+
+      // const nullifierSeed = Field.random();
+      const nullifierHash = nullifier(Field.from(0), photoChunks);
+
+      expect(nullifierHash.toBigInt()).toEqual(10925948596859628672570915913938655172287655450674278034619273873192962315293n);
     });
   });
 });

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -213,18 +213,18 @@ function stateExtractor(nDelimitedData: Field[], delimiterIndices: Field[]) {
 }
 
 /**
- * Extracts the photo data field from the delimited data.
+ * Extracts the photo data field from the delimited input.
  *
- * The photo field spans a fixed-size byte block calculated by
- * `MAX_FIELD_BYTE_SIZE * PHOTO_PACK_SIZE`. This function locates
- * the start position using the delimiter indices and then selects
- * the corresponding subarray.
+ * The photo field spans a fixed-size byte block determined by
+ * `MAX_FIELD_BYTE_SIZE * PHOTO_PACK_SIZE`. This function calculates
+ * the start position using the `delimiterIndices` and selects the
+ * corresponding subarray of photo bytes.
  *
  * Rows: ~100k
  *
- * @param {Field[]} nDelimitedData - The delimited input data array.
- * @param {Field[]} delimiterIndices - Array of indices marking field positions.
- * @returns {Field[]} An array representing the extracted photo data bytes.
+ * @param {Field[]} nDelimitedData - The full delimited input data as an array of Fields.
+ * @param {Field[]} delimiterIndices - Array of Fields marking the start of each field.
+ * @returns {Field[]} An array of Fields representing the extracted photo data bytes.
  */
 function photoExtractor(nDelimitedData: Field[], delimiterIndices: Field[]) {
   const byteLength = MAX_FIELD_BYTE_SIZE * PHOTO_PACK_SIZE;
@@ -237,18 +237,17 @@ function photoExtractor(nDelimitedData: Field[], delimiterIndices: Field[]) {
 }
 
 /**
- * Extracts the photo data field from the delimited data and packs data to an array of length 32. 
+ * Extracts and packs the photo data field into an array of 32 `Field` values.
  *
- * The photo field spans a fixed-size byte block calculated by
- * `MAX_FIELD_BYTE_SIZE * PHOTO_PACK_SIZE`. This function locates
- * the start position using the delimiter indices and then selects
- * the corresponding subarray.
+ * First, the raw photo byte data is extracted using `photoExtractor`. Then,
+ * it is split into 32 chunks of 31 bytes each, and each chunk is packed into
+ * a single `Field` using the `pack` function.
  *
- * Rows: ~100k
+ * The result is a compact representation of the photo suitable for ZK circuits.
  *
- * @param {Field[]} nDelimitedData - The delimited input data array.
- * @param {Field[]} delimiterIndices - Array of indices marking field positions.
- * @returns {Field[]} An array representing the extracted photo data bytes.
+ * @param {Field[]} nDelimitedData - The full delimited input data as an array of Fields.
+ * @param {Field[]} delimiterIndices - Array of Fields marking the start of each field.
+ * @returns {Field[]} A 32-element array of packed Fields representing the photo.
  */
 function photoExtractorChunked(nDelimitedData: Field[], delimiterIndices: Field[]) {
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -20,6 +20,7 @@ export {
   ageAndGenderExtractor,
   pincodeExtractor,
   stateExtractor,
+  photoExtractor,
   photoExtractorChunked
 };
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -21,7 +21,7 @@ export {
   pincodeExtractor,
   stateExtractor,
   photoExtractor,
-  photoExtractorChunked
+  photoExtractorChunked,
 };
 
 /**
@@ -233,7 +233,7 @@ function photoExtractor(nDelimitedData: Field[], delimiterIndices: Field[]) {
   const startIndex = delimiterIndices[PHOTO_POSITION - 1].add(1);
 
   const selectedArray = selectSubarray(nDelimitedData, startIndex, byteLength);
-  
+
   return selectedArray;
 }
 
@@ -250,15 +250,17 @@ function photoExtractor(nDelimitedData: Field[], delimiterIndices: Field[]) {
  * @param {Field[]} delimiterIndices - Array of Fields marking the start of each field.
  * @returns {Field[]} A 32-element array of packed Fields representing the photo.
  */
-function photoExtractorChunked(nDelimitedData: Field[], delimiterIndices: Field[]) {
-
+function photoExtractorChunked(
+  nDelimitedData: Field[],
+  delimiterIndices: Field[]
+) {
   let selectedArray = photoExtractor(nDelimitedData, delimiterIndices);
 
   let byteChunks = chunk(selectedArray, 31);
 
   let photoArray = [];
 
-  for(let i = 0; i < 32; i ++){
+  for (let i = 0; i < 32; i++) {
     const packedData = pack(byteChunks[i]);
 
     photoArray.push(packedData);

--- a/src/nullifier.ts
+++ b/src/nullifier.ts
@@ -1,7 +1,7 @@
-import { Field, Poseidon } from "o1js";
-export {nullifier};
+import { Field, Poseidon } from 'o1js';
+export { nullifier };
 
-function nullifier(nullifierSeed: Field, photo: Field[]){
-    const first16 = Poseidon.hash(photo);
-    return Poseidon.hash([nullifierSeed,first16]);
+function nullifier(nullifierSeed: Field, photo: Field[]) {
+  const first16 = Poseidon.hash(photo);
+  return Poseidon.hash([nullifierSeed, first16]);
 }

--- a/src/nullifier.ts
+++ b/src/nullifier.ts
@@ -2,6 +2,6 @@ import { Field, Poseidon } from 'o1js';
 export { nullifier };
 
 function nullifier(nullifierSeed: Field, photo: Field[]) {
-  const first16 = Poseidon.hash(photo);
-  return Poseidon.hash([nullifierSeed, first16]);
+  const photoHash = Poseidon.hash(photo);
+  return Poseidon.hash([nullifierSeed, photoHash]);
 }

--- a/src/nullifier.ts
+++ b/src/nullifier.ts
@@ -1,0 +1,7 @@
+import { Field, Poseidon } from "o1js";
+export {nullifier};
+
+function nullifier(nullifierSeed: Field, photo: Field[]){
+    const first16 = Poseidon.hash(photo);
+    return Poseidon.hash([nullifierSeed,first16]);
+}

--- a/src/recursion.ts
+++ b/src/recursion.ts
@@ -81,49 +81,49 @@ const hashProgramWrapper = ZkProgram({
 
 let recursiveHash = Experimental.Recursive(hashProgramWrapper);
 
-  /**
-   * Recursively hashes a sequence of Merkle blocks using a proof system.
-   *
-   * This function splits the input blocks into two parts:
-   * - A "tail" of blocks to be hashed directly.
-   * - A "remaining" prefix to be hashed recursively or using a base method.
-   *
-   * The result is a SHA-256 style hash after applying all block transformations.
-   *
-   * @param {MerkleBlocks} blocks - The full array of Merkle blocks to hash.
-   * @param {{ blocksInThisProof: number }} options - The number of blocks to include in the current proof.
-   * @returns {Promise<State32>} The resulting state after hashing all blocks.
-   * @notice - Taken from https://github.com/zksecurity/mina-attestations/blob/835d8d47566c4c065fa34c88af7ce99a5993425c/src/email/zkemail.ts#L210
-   */
-  async function hashBlocks(
-    blocks: MerkleBlocks,
-    numberOfBlocks: number
-  ): Promise<State32> {
-    // Popping `numberOfBlocks` amount of blocks from the MerkleBlocks
-    let { remaining, tail } = MerkleBlocks.popTail(blocks, numberOfBlocks);
+/**
+ * Recursively hashes a sequence of Merkle blocks using a proof system.
+ *
+ * This function splits the input blocks into two parts:
+ * - A "tail" of blocks to be hashed directly.
+ * - A "remaining" prefix to be hashed recursively or using a base method.
+ *
+ * The result is a SHA-256 style hash after applying all block transformations.
+ *
+ * @param {MerkleBlocks} blocks - The full array of Merkle blocks to hash.
+ * @param {{ blocksInThisProof: number }} options - The number of blocks to include in the current proof.
+ * @returns {Promise<State32>} The resulting state after hashing all blocks.
+ * @notice - Taken from https://github.com/zksecurity/mina-attestations/blob/835d8d47566c4c065fa34c88af7ce99a5993425c/src/email/zkemail.ts#L210
+ */
+async function hashBlocks(
+  blocks: MerkleBlocks,
+  numberOfBlocks: number
+): Promise<State32> {
+  // Popping `numberOfBlocks` amount of blocks from the MerkleBlocks
+  let { remaining, tail } = MerkleBlocks.popTail(blocks, numberOfBlocks);
 
-    // Apply recursive hashing in witness blocks. Later on, remanining MerkleBlock's hash commitment can be checked with the recursionProof's output to see if correct blocks are used.
-    let recursionProof = await Provable.witnessAsync(
-      hashProgram.Proof,
-      async () => {
-        // convert the blocks to constants
-        let blocksForProof = Provable.toConstant(MerkleBlocks, remaining.clone());
+  // Apply recursive hashing in witness blocks. Later on, remanining MerkleBlock's hash commitment can be checked with the recursionProof's output to see if correct blocks are used.
+  let recursionProof = await Provable.witnessAsync(
+    hashProgram.Proof,
+    async () => {
+      // convert the blocks to constants
+      let blocksForProof = Provable.toConstant(MerkleBlocks, remaining.clone());
 
-        // If remaining blocks of recursive approach is less than a threshold (BLOCKS_PER_BASE_PROOF), a base hashing is applied.
-        let remainingBlocks = remaining.lengthUnconstrained().get();
+      // If remaining blocks of recursive approach is less than a threshold (BLOCKS_PER_BASE_PROOF), a base hashing is applied.
+      let remainingBlocks = remaining.lengthUnconstrained().get();
 
-        // Define the proof variable that will be returned.
-        let proof: Proof<MerkleBlocks, State32>;
+      // Define the proof variable that will be returned.
+      let proof: Proof<MerkleBlocks, State32>;
 
-        // Choose which hashing method will be used depending on the remainingBlocks.
-        if (remainingBlocks <= BLOCKS_PER_BASE_PROOF) {
-          ({ proof } = await hashProgram.hashBase(blocksForProof));
-        } else {
-          ({ proof } = await hashProgram.hashRecursive(blocksForProof));
-        }
-        return proof;
+      // Choose which hashing method will be used depending on the remainingBlocks.
+      if (remainingBlocks <= BLOCKS_PER_BASE_PROOF) {
+        ({ proof } = await hashProgram.hashBase(blocksForProof));
+      } else {
+        ({ proof } = await hashProgram.hashRecursive(blocksForProof));
       }
-    );
+      return proof;
+    }
+  );
 
   // Use declare method to verify proof inside of ZkProgram as if it was an input to the circuit.
   recursionProof.declare();

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -197,11 +197,11 @@ async function generateHashFromData(data: Uint8Array): Promise<Bytes> {
 /**
  * Asserts that the signature verification inside the circuit fails as expected,
  * and checks that the appropriate error messages are thrown depending on proof settings.
- * 
+ *
  * @remarks
- * This function differs from {@link expectSignatureError} by executing circuits rather than 
- * RSA verification with off-circuit methods. It uses the `SignatureVerifier.verifySignature` 
- * method, which relies on the ZkProgram circuit, whereas `expectSignatureError` checks it with 
+ * This function differs from {@link expectSignatureError} by executing circuits rather than
+ * RSA verification with off-circuit methods. It uses the `SignatureVerifier.verifySignature`
+ * method, which relies on the ZkProgram circuit, whereas `expectSignatureError` checks it with
  * off- circuit function that is also used in `SignatureVerifier.verifySignature`.
  *
  * @see {@link expectSignatureError}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,8 @@ export {
   state32ToBytes,
   padding256,
   generateMessageBlocks,
+  pack,
+  chunk
 };
 
 /**
@@ -608,4 +610,28 @@ function padding256(
  */
 function state32ToBytes(state: State32) {
   return Bytes.from(state.array.flatMap((x) => x.toBytesBE()));
+}
+
+/**
+ * Packs an array of 32 `Field` elements into a single `Field`,
+ * assuming each chunk is 32 bits wide, using little-endian encoding.
+ *
+ * Each chunk is multiplied by 2^(i * 32), where `i` is its index in the array.
+ *
+ * @param {Field[]} chunks - Array of 32-bit chunks as `Field` elements.
+ * @returns {Field} A single packed `Field`.
+ * @throws Will throw an error if the number of chunks is not 32.
+ * 
+ * @notice Taken from https://github.com/zksecurity/mina-attestations/blob/312cabf04fbc5e218699a318a39267a8eca7f074/src/dynamic/gadgets.ts#L35
+ */
+function pack(chunks: Field[]): Field {
+  assert(
+    chunks.length != 32,
+    `Chunk length is not satisfied, expected 32, got ${chunks.length}`
+  );
+  let sum = Field(0);
+  chunks.forEach((chunk, i) => {
+    sum = sum.add(chunk.mul(1n << BigInt(i * 32)));
+  });
+  return sum.seal();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export {
   padding256,
   generateMessageBlocks,
   pack,
-  chunk
+  chunk,
 };
 
 /**
@@ -621,7 +621,7 @@ function state32ToBytes(state: State32) {
  * @param {Field[]} chunks - Array of 32-bit chunks as `Field` elements.
  * @returns {Field} A single packed `Field`.
  * @throws Will throw an error if the number of chunks is not 32.
- * 
+ *
  * @notice Taken from https://github.com/zksecurity/mina-attestations/blob/312cabf04fbc5e218699a318a39267a8eca7f074/src/dynamic/gadgets.ts#L35
  */
 function pack(chunks: Field[]): Field {


### PR DESCRIPTION
### Description

Im this PR, implementation of the core nullifier logic is done. 
- `pack(chunks: Field[]): Field` method is introduced to pack the 992 long byte array to an array of length 32, where each element is the packed 31 byte Field element. 10df9daa74fcbd971b0f67a2b6cbce7e52ef36fb
- Nullifier logic is implemented. Different from other implementations, where data is fed by splitting it to 16 elements and hashing together, all 32 elements are hashed, later it is hashed with `nullifierSeed` for randomness. 1d2d599b3563ea03fda9a324726ce469ca093eaf
- Add a (kinda trivial) test for nullifier logic. 85d683ec60799202f77514724203ac00428c4914